### PR TITLE
Fix to make :writable-stack-trace-enabled work

### DIFF
--- a/src/resilience/bulkhead.clj
+++ b/src/resilience/bulkhead.clj
@@ -42,7 +42,7 @@
       (when-let [wait-millis (:max-wait-millis opts)]
         (.maxWaitDuration config (Duration/ofMillis wait-millis)))
 
-      (when-let [stack-trace-enabled (:writable-stack-trace-enabled opts)]
+      (when-some [stack-trace-enabled (:writable-stack-trace-enabled opts)]
         (.writableStackTraceEnabled config stack-trace-enabled))
 
       (.build config))))


### PR DESCRIPTION
`when-let` does nothing if the condition is `false` so `{:writable-stack-trace-enabled false}` would have no effect

Before: 

```clojure
(.isWritableStackTraceEnabled (resilience.bulkhead/bulkhead-config {:writable-stack-trace-enabled false}))
; => true
```